### PR TITLE
Add more configuration options

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
       continue-on-error:
-        description: "Don't mark the job as failed if a lint fails"
+        description: "don't mark the job as failed if a lint fails"
         default: false
         required: false
         type: boolean
@@ -26,7 +26,7 @@ on:
         required: false
         type: string
       python-version-file:
-        description: "get the python version from the specified file"
+        description: "get the Python version from the specified file"
         default: ".python-version"
         required: false
         type: string
@@ -50,7 +50,7 @@ on:
         required: false
         type: string
       go-version-file:
-        description: "the file to get the go version from"
+        description: "the file to get the Go version from"
         default: "go.mod"
         required: false
         type: string

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,10 @@ env:
   # Python: Tell ruff that we're in GitHub Actions, so that it emits annotations.
   RUFF_FORMAT: github
 
+  # Python: Make-based linting workflows use `INSTALL_EXTRA` to optimize
+  # the subset of development dependencies installed.
+  INSTALL_EXTRA: lint
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -123,11 +127,7 @@ jobs:
       - name: run lint (make)
         if: (inputs.language == 'python' && inputs.type == '') || inputs.type == 'make'
         continue-on-error: ${{ inputs.continue-on-error }}
-        # NOTE: INSTALL_EXTRA is an optimization that many of our Python packages use:
-        # it limits the dependency set to just the specified extra, in this case `lint`.
-        # It has no effect on non-Python lint suites.
-        run: |
-          make lint INSTALL_EXTRA=lint
+        run: make lint
         working-directory: "${{ inputs.directory }}"
 
       # Just

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,8 +75,8 @@ jobs:
       - name: configure python, if required
         if: inputs.language == 'python'
         uses: actions/setup-python@v4
-        working-directory: "${{ inputs.directory }}"
         with:
+          working-directory: "${{ inputs.directory }}"
           python-version: "${{ inputs.python-version }}"
           python-version-file: "${{ inputs.python-version-file }}"
           cache: pip
@@ -87,12 +87,13 @@ jobs:
       # Rust
       - name: configure rust and clippy, if required
         if: inputs.language == 'rust' 
-        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         run: |
           # we always run the latest stable Rust and Clippy for Rust linting.
           rustup update
           rustup component add clippy
+        with:
+          working-directory: "${{ inputs.directory }}"
 
       - name: run rustfmt (rust)
         if: inputs.language == 'rust' && inputs.type == 'github'
@@ -105,45 +106,46 @@ jobs:
         # which is no longer maintained; the commit is pinned since no release
         # has been made and its long term maintenance status/ownership is unclear.
         if: inputs.language == 'rust' && inputs.type == 'github'
-        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
         with:
+          working-directory: "${{ inputs.directory }}"
           args: --all-features -- -D warnings
 
       - name: run cargo sort (rust)
         if: inputs.language == 'rust' && inputs.type == 'github'
-        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         run: |
           cargo install cargo-sort
           cargo sort -c
+        with:
+          working-directory: "${{ inputs.directory }}"
 
       # Go
       - name: configure go, if required
         if: inputs.language == 'go'
-        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions/setup-go@v3
         with:
+          working-directory: "${{ inputs.directory }}"
           go-version-file: "${{ inputs.go-version-file }}"
           go-version: "${{ inputs.go-version }}"
 
       - name: run golangci-lint (go)
         if: inputs.language == 'go' && inputs.type == 'github'
-        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # @v3.3.1
         with:
+          working-directory: "${{ inputs.directory }}"
           version: "${{ inputs.golangci-lint-version }}"
 
       # Make
       - name: run lint (make)
         if: inputs.type == 'make'
-        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         run: make lint
-
+        with:
+          working-directory: "${{ inputs.directory }}"
       # Just
       - name: configure just, if required
         if: inputs.type == 'just'
@@ -153,3 +155,5 @@ jobs:
         if: inputs.type == 'just'
         continue-on-error: ${{ inputs.continue-on-error }}
         run: just lint
+        with:
+          working-directory: "${{ inputs.directory }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,12 +4,11 @@ on:
       type:
         description: "the expected lint entrypoint: make, just, or github"
         default: "github"
-        required: false
+        required: true
         type: string
       language:
         description: "the language to configure"
-        default: ""
-        required: false
+        required: true
         type: string
       target:
         description: "the make or just target to run for linting"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,11 @@ on:
         description: "the language to configure"
         required: true
         type: string
+      continue-on-error:
+        description: "Don't mark the job as failed if a lint fails"
+        default: false
+        required: false
+        type: boolean
       target:
         description: "the make or just target to run for linting"
         default: "lint"
@@ -70,7 +75,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-
+    continue-on-error: ${{ inputs.continue-on-error }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,6 @@ on:
         default: false
         required: false
         type: boolean
-      target:
-        description: "the make or just target to run for linting"
-        default: "lint"
-        required: false
-        type: string
       python-version:
         description: "the version of Python to configure, if any (can be SemVer-formatted)"
         default: ""
@@ -143,7 +138,7 @@ jobs:
       - name: run lint (make)
         if: inputs.type == 'make'
         continue-on-error: ${{ inputs.continue-on-error }}
-        run: make "${{ inputs.target }}"
+        run: make lint
 
       # Just
       - name: configure just, if required
@@ -152,4 +147,4 @@ jobs:
       - name: run lint (just)
         if: inputs.type == 'just'
         continue-on-error: ${{ inputs.continue-on-error }}
-        run: just "${{ inputs.target }}"
+        run: just lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -151,7 +151,7 @@ jobs:
       # Just
       - name: configure just, if required
         if: inputs.type == 'just'
-        uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76 # @v1
+        run: cargo install just
       - name: run lint (just)
         if: inputs.type == 'just'
         continue-on-error: ${{ inputs.continue-on-error }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,8 +65,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: validate input
+        env:
+          INPUT_LANGUAGE: "${{ inputs.language }}"
+          INPUT_TYPE: "${{ inputs.type }}"
         run: |
-          if [ "${{ inputs.language }}" == "python" ] && [ "${{ inputs.type }}" == "github" ]; then
+          if [ "${INPUT_LANGUAGE}" == "python" ] && [ "${INPUT_TYPE}" == "github" ]; then
             echo "you must use either make or just to run a lint target for python"
             exit 1
           fi
@@ -86,7 +89,7 @@ jobs:
 
       # Rust
       - name: configure rust and clippy, if required
-        if: inputs.language == 'rust' 
+        if: inputs.language == 'rust'
         continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: "${{ inputs.directory }}"
         run: |
@@ -141,12 +144,18 @@ jobs:
       - name: run lint (make)
         if: inputs.type == 'make'
         continue-on-error: ${{ inputs.continue-on-error }}
-        run: make lint
+        # NOTE: INSTALL_EXTRA is an optimization that many of our Python packages use:
+        # it limits the dependency set to just the specified extra, in this case `lint`.
+        # It has no effect on non-Python lint suites.
+        run: |
+          make lint INSTALL_EXTRA=lint
         working-directory: "${{ inputs.directory }}"
+
       # Just
       - name: configure just, if required
         if: inputs.type == 'just'
         run: cargo install just
+
       - name: run lint (just)
         if: inputs.type == 'just'
         continue-on-error: ${{ inputs.continue-on-error }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,11 +4,12 @@ on:
       type:
         description: "the expected lint entrypoint: make, just, or github"
         default: "github"
-        required: true
+        required: false
         type: string
       language:
         description: "the language to configure"
-        required: true
+        default: ""
+        required: false
         type: string
       target:
         description: "the make or just target to run for linting"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,11 +25,6 @@ on:
         default: ""
         required: false
         type: string
-      python-version-file:
-        description: "get the Python version from the specified file"
-        default: ".python-version"
-        required: false
-        type: string
       go-version:
         description: "the Go version"
         default: ""
@@ -64,9 +59,8 @@ jobs:
         if: inputs.language == 'python'
         uses: actions/setup-python@v4
         with:
-          working-directory: "${{ inputs.directory }}"
           python-version: "${{ inputs.python-version }}"
-          python-version-file: "${{ inputs.python-version-file }}"
+          python-version-file: "${{ inputs.directory }}/.python-version"
           cache: pip
           cache-dependency-path: |
             **/pyproject.toml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,17 +88,16 @@ jobs:
       - name: configure rust and clippy, if required
         if: inputs.language == 'rust' 
         continue-on-error: ${{ inputs.continue-on-error }}
+        working-directory: "${{ inputs.directory }}"
         run: |
           # we always run the latest stable Rust and Clippy for Rust linting.
           rustup update
           rustup component add clippy
-        with:
-          working-directory: "${{ inputs.directory }}"
 
       - name: run rustfmt (rust)
         if: inputs.language == 'rust' && inputs.type == 'github'
-        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
+        working-directory: "${{ inputs.directory }}"
         run: cargo fmt --check
 
       - name: run clippy (rust)
@@ -109,17 +108,16 @@ jobs:
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
         with:
-          working-directory: "${{ inputs.directory }}"
           args: --all-features -- -D warnings
+          working-directory: "${{ inputs.directory }}"
 
       - name: run cargo sort (rust)
         if: inputs.language == 'rust' && inputs.type == 'github'
         continue-on-error: ${{ inputs.continue-on-error }}
+        working-directory: "${{ inputs.directory }}"
         run: |
           cargo install cargo-sort
           cargo sort -c
-        with:
-          working-directory: "${{ inputs.directory }}"
 
       # Go
       - name: configure go, if required
@@ -127,17 +125,17 @@ jobs:
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions/setup-go@v3
         with:
-          working-directory: "${{ inputs.directory }}"
           go-version-file: "${{ inputs.go-version-file }}"
           go-version: "${{ inputs.go-version }}"
+          working-directory: "${{ inputs.directory }}"
 
       - name: run golangci-lint (go)
         if: inputs.language == 'go' && inputs.type == 'github'
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # @v3.3.1
         with:
-          working-directory: "${{ inputs.directory }}"
           version: "${{ inputs.golangci-lint-version }}"
+          working-directory: "${{ inputs.directory }}"
 
       # Make
       - name: run lint (make)
@@ -149,11 +147,9 @@ jobs:
       # Just
       - name: configure just, if required
         if: inputs.type == 'just'
-        working-directory: "${{ inputs.directory }}"
         run: cargo install just
       - name: run lint (just)
         if: inputs.type == 'just'
         continue-on-error: ${{ inputs.continue-on-error }}
         run: just lint
-        with:
-          working-directory: "${{ inputs.directory }}"
+        working-directory: "${{ inputs.directory }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,11 +56,7 @@ env:
   CARGO_TERM_COLOR: always
 
   # Python: Tell ruff that we're in GitHub Actions, so that it emits annotations.
-  RUFF_FORMAT: github
-
-defaults:
-  run:
-    working-directory: "${{ inputs.directory }}"
+  RUFF_FORMAT: github 
 
 jobs:
   lint:
@@ -79,6 +75,7 @@ jobs:
       - name: configure python, if required
         if: inputs.language == 'python'
         uses: actions/setup-python@v4
+        working-directory: "${{ inputs.directory }}"
         with:
           python-version: "${{ inputs.python-version }}"
           python-version-file: "${{ inputs.python-version-file }}"
@@ -90,6 +87,7 @@ jobs:
       # Rust
       - name: configure rust and clippy, if required
         if: inputs.language == 'rust' 
+        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         run: |
           # we always run the latest stable Rust and Clippy for Rust linting.
@@ -98,6 +96,7 @@ jobs:
 
       - name: run rustfmt (rust)
         if: inputs.language == 'rust' && inputs.type == 'github'
+        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         run: cargo fmt --check
 
@@ -106,6 +105,7 @@ jobs:
         # which is no longer maintained; the commit is pinned since no release
         # has been made and its long term maintenance status/ownership is unclear.
         if: inputs.language == 'rust' && inputs.type == 'github'
+        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
         with:
@@ -113,6 +113,7 @@ jobs:
 
       - name: run cargo sort (rust)
         if: inputs.language == 'rust' && inputs.type == 'github'
+        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         run: |
           cargo install cargo-sort
@@ -121,6 +122,7 @@ jobs:
       # Go
       - name: configure go, if required
         if: inputs.language == 'go'
+        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions/setup-go@v3
         with:
@@ -129,6 +131,7 @@ jobs:
 
       - name: run golangci-lint (go)
         if: inputs.language == 'go' && inputs.type == 'github'
+        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # @v3.3.1
         with:
@@ -137,12 +140,14 @@ jobs:
       # Make
       - name: run lint (make)
         if: inputs.type == 'make'
+        working-directory: "${{ inputs.directory }}"
         continue-on-error: ${{ inputs.continue-on-error }}
         run: make lint
 
       # Just
       - name: configure just, if required
         if: inputs.type == 'just'
+        working-directory: "${{ inputs.directory }}"
         run: cargo install just
       - name: run lint (just)
         if: inputs.type == 'just'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,6 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ inputs.continue-on-error }}
     steps:
       - uses: actions/checkout@v3
 
@@ -99,6 +98,7 @@ jobs:
       # Rust
       - name: configure rust and clippy, if required
         if: inputs.language == 'rust' 
+        continue-on-error: ${{ inputs.continue-on-error }}
         run: |
           # we always run the latest stable Rust and Clippy for Rust linting.
           rustup update
@@ -106,19 +106,22 @@ jobs:
 
       - name: run rustfmt (rust)
         if: inputs.language == 'rust' && inputs.type == 'github'
+        continue-on-error: ${{ inputs.continue-on-error }}
         run: cargo fmt --check
 
       - name: run clippy (rust)
         # NOTE: This is a fork of the original `actions-rs/clippy-check`,
         # which is no longer maintained; the commit is pinned since no release
         # has been made and its long term maintenance status/ownership is unclear.
-        uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
         if: inputs.language == 'rust' && inputs.type == 'github'
+        continue-on-error: ${{ inputs.continue-on-error }}
+        uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
         with:
           args: --all-features -- -D warnings
 
       - name: run cargo sort (rust)
         if: inputs.language == 'rust' && inputs.type == 'github'
+        continue-on-error: ${{ inputs.continue-on-error }}
         run: |
           cargo install cargo-sort
           cargo sort -c
@@ -126,6 +129,7 @@ jobs:
       # Go
       - name: configure go, if required
         if: inputs.language == 'go'
+        continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions/setup-go@v3
         with:
           go-version-file: "${{ inputs.go-version-file }}"
@@ -133,6 +137,7 @@ jobs:
 
       - name: run golangci-lint (go)
         if: inputs.language == 'go' && inputs.type == 'github'
+        continue-on-error: ${{ inputs.continue-on-error }}
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # @v3.3.1
         with:
           version: "${{ inputs.golangci-lint-version }}"
@@ -140,6 +145,7 @@ jobs:
       # Make
       - name: run lint (make)
         if: inputs.type == 'make'
+        continue-on-error: ${{ inputs.continue-on-error }}
         run: make "${{ inputs.target }}"
 
       # Just
@@ -148,4 +154,5 @@ jobs:
         uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76 # @v1
       - name: run lint (just)
         if: inputs.type == 'just'
+        continue-on-error: ${{ inputs.continue-on-error }}
         run: just "${{ inputs.target }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,11 +35,6 @@ on:
         default: ""
         required: false
         type: string
-      go-version-file:
-        description: "the file to get the Go version from"
-        default: "go.mod"
-        required: false
-        type: string
       golangci-lint-version:
         description: "the golangci-lint version for Go linting"
         default: "v1.50.1"
@@ -128,7 +123,7 @@ jobs:
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions/setup-go@v3
         with:
-          go-version-file: "${{ inputs.go-version-file }}"
+          go-version-file: "${{ inputs.directory }}/go.mod"
           go-version: "${{ inputs.go-version }}"
           working-directory: "${{ inputs.directory }}"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,11 @@ on:
         default: "make"
         required: false
         type: string
+      target:
+        description: "the make or just target to run for linting"
+        default: "lint"
+        required: false
+        type: string
       python-version:
         description: "the version of Python to configure, if any (can be SemVer-formatted)"
         default: ""
@@ -122,9 +127,9 @@ jobs:
       # Make
       - name: run lint (make)
         if: contains(inputs.type, 'make')
-        run: make lint
+        run: make "${{ inputs.target }}"
 
       # Just
       - name: run lint (just)
         if: contains(inputs.type, 'just')
-        run: just lint
+        run: just "${{ inputs.target }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,8 @@ on:
   workflow_call:
     inputs:
       type:
-        description: "the expected lint entrypoint: make, just, or github"
-        default: "github"
+        description: "the expected lint entrypoint (derived from language by default)"
+        default: ""
         required: false
         type: string
       language:
@@ -59,16 +59,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: validate input
-        env:
-          INPUT_LANGUAGE: "${{ inputs.language }}"
-          INPUT_TYPE: "${{ inputs.type }}"
-        run: |
-          if [ "${INPUT_LANGUAGE}" == "python" ] && [ "${INPUT_TYPE}" == "github" ]; then
-            echo "you must use either make or just to run a lint target for python"
-            exit 1
-          fi
-
       # Python
       - name: configure python, if required
         if: inputs.language == 'python'
@@ -93,7 +83,7 @@ jobs:
           rustup component add clippy
 
       - name: run rustfmt (rust)
-        if: inputs.language == 'rust' && inputs.type == 'github'
+        if: inputs.language == 'rust' && inputs.type == ''
         continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: "${{ inputs.directory }}"
         run: cargo fmt --check
@@ -102,7 +92,7 @@ jobs:
         # NOTE: This is a fork of the original `actions-rs/clippy-check`,
         # which is no longer maintained; the commit is pinned since no release
         # has been made and its long term maintenance status/ownership is unclear.
-        if: inputs.language == 'rust' && inputs.type == 'github'
+        if: inputs.language == 'rust' && inputs.type == ''
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
         with:
@@ -110,7 +100,7 @@ jobs:
           working-directory: "${{ inputs.directory }}"
 
       - name: run cargo sort (rust)
-        if: inputs.language == 'rust' && inputs.type == 'github'
+        if: inputs.language == 'rust' && inputs.type == ''
         continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: "${{ inputs.directory }}"
         run: |
@@ -128,7 +118,7 @@ jobs:
           working-directory: "${{ inputs.directory }}"
 
       - name: run golangci-lint (go)
-        if: inputs.language == 'go' && inputs.type == 'github'
+        if: inputs.language == 'go' && inputs.type == ''
         continue-on-error: ${{ inputs.continue-on-error }}
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # @v3.3.1
         with:
@@ -137,7 +127,7 @@ jobs:
 
       # Make
       - name: run lint (make)
-        if: inputs.type == 'make'
+        if: (inputs.language == 'python' && inputs.type == '') || inputs.type == 'make'
         continue-on-error: ${{ inputs.continue-on-error }}
         # NOTE: INSTALL_EXTRA is an optimization that many of our Python packages use:
         # it limits the dependency set to just the specified extra, in this case `lint`.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ inputs.continue-on-error }}
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: ${{ inputs.continue-on-error }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,13 @@ on:
   workflow_call:
     inputs:
       type:
-        description: >
-          the expected lint entrypoint: comma separated language names
-          or one of 'make' or 'just'
-          along with comma separated languages to set up
-        default: "make"
-        required: false
+        description: "the expected lint entrypoint: make, just, or github"
+        default: "github"
+        required: true
+        type: string
+      language:
+        description: "the language to configure"
+        required: true
         type: string
       target:
         description: "the make or just target to run for linting"
@@ -75,7 +76,7 @@ jobs:
 
       # Python
       - name: configure python, if required
-        if: contains(inputs.type, 'python')
+        if: inputs.language == 'python'
         uses: actions/setup-python@v4
         with:
           python-version: "${{ inputs.python-version }}"
@@ -85,14 +86,14 @@ jobs:
 
       # Rust
       - name: configure rust and clippy, if required
-        if: contains(inputs.type, 'rust')
+        if: inputs.language == 'rust' 
         run: |
           # we always run the latest stable Rust and Clippy for Rust linting.
           rustup update
           rustup component add clippy
 
       - name: run rustfmt (rust)
-        if: contains(inputs.type, 'rust')
+        if: inputs.language == 'rust' && inputs.type == 'github'
         run: cargo fmt --check
 
       - name: run clippy (rust)
@@ -100,36 +101,39 @@ jobs:
         # which is no longer maintained; the commit is pinned since no release
         # has been made and its long term maintenance status/ownership is unclear.
         uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
-        if: contains(inputs.type, 'rust')
+        if: inputs.language == 'rust' && inputs.type == 'github'
         with:
           args: --all-features -- -D warnings
 
       - name: run cargo sort (rust)
-        if: contains(inputs.type, 'rust') && inputs.cargo-sort
+        if: inputs.language == 'rust' && inputs.type == 'github'
         run: |
           cargo install cargo-sort
           cargo sort -c
 
       # Go
-      - name: setup go
-        if: contains(inputs.type, 'go')
+      - name: configure go, if required
+        if: inputs.language == 'go'
         uses: actions/setup-go@v3
         with:
           go-version-file: "${{ inputs.go-version-file }}"
           go-version: "${{ inputs.go-version }}"
 
       - name: run golangci-lint (go)
-        if: contains(inputs.type, 'go')
+        if: inputs.language == 'go' && inputs.type == 'github'
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # @v3.3.1
         with:
           version: "${{ inputs.golangci-lint-version }}"
 
       # Make
       - name: run lint (make)
-        if: contains(inputs.type, 'make')
+        if: inputs.type == 'make'
         run: make "${{ inputs.target }}"
 
       # Just
+      - name: configure just, if required
+        if: inputs.type == 'just'
+        uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76 # @v1
       - name: run lint (just)
-        if: contains(inputs.type, 'just')
+        if: inputs.type == 'just'
         run: just "${{ inputs.target }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,15 +78,6 @@ jobs:
           cache: "${{ inputs.python-cache-type }}"
           cache-dependency-path: "${{ inputs.python-cache-dependency-path }}"
 
-      - name: validate input (python)
-        if: contains(inputs.type, 'python')
-        run: |
-          if [[ "${{ inputs.python-version }}" == "" \
-            && "${{ inputs.python-version-file }}" == ""]]; then
-            echo "Must set either python-version or python-version-file"
-            exit 1
-          fi
-
       # Rust
       - name: configure rust and clippy, if required
         if: contains(inputs.type, 'rust')
@@ -121,15 +112,6 @@ jobs:
         with:
           go-version-file: "${{ inputs.go-version-file }}"
           go-version: "${{ inputs.go-version }}"
-
-      - name: validate input (go)
-        if: contains(inputs.type, 'go')
-        run: |
-          if [[ "${{ inputs.go-version }}" == "" \
-            && "${{ inputs.go-version-file }}" == ""]]; then
-            echo "Must set either go-version or go-version-file"
-            exit 1
-          fi
 
       - name: run golangci-lint (go)
         if: contains(inputs.type, 'go')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ env:
   CARGO_TERM_COLOR: always
 
   # Python: Tell ruff that we're in GitHub Actions, so that it emits annotations.
-  RUFF_FORMAT: github 
+  RUFF_FORMAT: github
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,6 +74,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: validate input
+        run: |
+          if [ "${{ inputs.language }}" == "python" ] && [ "${{ inputs.type }}" == "github" ]; then
+            echo "you must use either make or just to run a lint target for python"
+            exit 1
+          fi
+
       # Python
       - name: configure python, if required
         if: inputs.language == 'python'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -142,8 +142,7 @@ jobs:
         if: inputs.type == 'make'
         continue-on-error: ${{ inputs.continue-on-error }}
         run: make lint
-        with:
-          working-directory: "${{ inputs.directory }}"
+        working-directory: "${{ inputs.directory }}"
       # Just
       - name: configure just, if required
         if: inputs.type == 'just'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,39 @@ on:
   workflow_call:
     inputs:
       type:
-        description: "the expected lint entrypoint: a language name or either 'make' or 'just'"
+        description: >
+          the expected lint entrypoint: comma separated language names
+          or one of 'make' or 'just'
+          along with comma separated languages to set up
         default: "make"
         required: false
         type: string
       python-version:
         description: "the version of Python to configure, if any (can be SemVer-formatted)"
+        default: ""
+        required: false
+        type: string
+      python-version-file:
+        description: "get the python version from the specified file"
+        default: ".python-version"
+        required: false
+        type: string
+      python-cache-dependency-path:
+        description: "the file(s) where dependencies are defined: pyproject.toml, requirements.txt, poetry.lock"
+        default: |
+          **/pyproject.toml
+          **/requirements*.txt
+          **/Pipfile.lock
+          **/poetry.lock
+        required: false
+        type: string
+      python-cache-type:
+        description: "the Python cache type: pip, poetry, pipenv"
+        default: "pip"
+        required: false
+        type: string
+      go-version:
+        description: "the Go version"
         default: ""
         required: false
         type: string
@@ -43,23 +70,33 @@ jobs:
 
       # Python
       - name: configure python, if required
-        if: inputs.python-version != ''
+        if: contains(inputs.type, 'python')
         uses: actions/setup-python@v4
         with:
           python-version: "${{ inputs.python-version }}"
-          cache: "pip"
-          cache-dependency-path: pyproject.toml
+          python-version-file: "${{ inputs.python-version-file }}"
+          cache: "${{ inputs.python-cache-type }}"
+          cache-dependency-path: "${{ inputs.python-cache-dependency-path }}"
+
+      - name: validate input (python)
+        if: contains(inputs.type, 'python')
+        run: |
+          if [[ "${{ inputs.python-version }}" == "" \
+            && "${{ inputs.python-version-file }}" == ""]]; then
+            echo "Must set either python-version or python-version-file"
+            exit 1
+          fi
 
       # Rust
       - name: configure rust and clippy, if required
-        if: inputs.type == 'rust'
+        if: contains(inputs.type, 'rust')
         run: |
           # we always run the latest stable Rust and Clippy for Rust linting.
           rustup update
           rustup component add clippy
 
       - name: run rustfmt (rust)
-        if: inputs.type == 'rust'
+        if: contains(inputs.type, 'rust')
         run: cargo fmt --check
 
       - name: run clippy (rust)
@@ -67,30 +104,45 @@ jobs:
         # which is no longer maintained; the commit is pinned since no release
         # has been made and its long term maintenance status/ownership is unclear.
         uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
-        if: inputs.type == 'rust'
+        if: contains(inputs.type, 'rust')
         with:
           args: --all-features -- -D warnings
 
       - name: run cargo sort (rust)
-        if: inputs.type == 'rust' && inputs.cargo-sort
+        if: contains(inputs.type, 'rust') && inputs.cargo-sort
         run: |
           cargo install cargo-sort
           cargo sort -c
 
       # Go
       - name: setup go
-        if: inputs.type == 'go'
+        if: contains(inputs.type, 'go')
         uses: actions/setup-go@v3
         with:
           go-version-file: "${{ inputs.go-version-file }}"
+          go-version: "${{ inputs.go-version }}"
+
+      - name: validate input (go)
+        if: contains(inputs.type, 'go')
+        run: |
+          if [[ "${{ inputs.go-version }}" == "" \
+            && "${{ inputs.go-version-file }}" == ""]]; then
+            echo "Must set either go-version or go-version-file"
+            exit 1
+          fi
 
       - name: run golangci-lint (go)
-        if: inputs.type == 'go'
+        if: contains(inputs.type, 'go')
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # @v3.3.1
         with:
           version: "${{ inputs.golangci-lint-version }}"
 
       # Make
       - name: run lint (make)
-        if: inputs.type == 'make'
+        if: contains(inputs.type, 'make')
         run: make lint
+
+      # Just
+      - name: run lint (just)
+        if: contains(inputs.type, 'just')
+        run: just lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
       type:
         description: "the expected lint entrypoint: make, just, or github"
         default: "github"
-        required: true
+        required: false
         type: string
       language:
         description: "the language to configure"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,11 @@ on:
         description: "the language to configure"
         required: true
         type: string
+      directory:
+        description: "the directory to run the lint in"
+        required: false
+        type: string
+        default: ${{ github.workspace }}
       continue-on-error:
         description: "don't mark the job as failed if a lint fails"
         default: false
@@ -28,20 +33,6 @@ on:
       python-version-file:
         description: "get the Python version from the specified file"
         default: ".python-version"
-        required: false
-        type: string
-      python-cache-dependency-path:
-        description: "the file(s) where dependencies are defined: pyproject.toml, requirements.txt, poetry.lock"
-        default: |
-          **/pyproject.toml
-          **/requirements*.txt
-          **/Pipfile.lock
-          **/poetry.lock
-        required: false
-        type: string
-      python-cache-type:
-        description: "the Python cache type: pip, poetry, pipenv"
-        default: "pip"
         required: false
         type: string
       go-version:
@@ -72,6 +63,10 @@ env:
   # Python: Tell ruff that we're in GitHub Actions, so that it emits annotations.
   RUFF_FORMAT: github
 
+defaults:
+  run:
+    working-directory: "${{ inputs.directory }}"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -92,8 +87,10 @@ jobs:
         with:
           python-version: "${{ inputs.python-version }}"
           python-version-file: "${{ inputs.python-version-file }}"
-          cache: "${{ inputs.python-cache-type }}"
-          cache-dependency-path: "${{ inputs.python-cache-dependency-path }}"
+          cache: pip
+          cache-dependency-path: |
+            **/pyproject.toml
+            **/requirements*.txt
 
       # Rust
       - name: configure rust and clippy, if required


### PR DESCRIPTION
- Refactors `type` to specify whether the lint will run make, just, or lint with a language specific github action.
- Adds a required `language` variable so that language setup can happen regardless of running from make/just or github.
- Defaults to getting the language version from a file, but that can still be overridden from an explicit version.
- Adds the the option to continue on error if a lint fails
- Adds input validation (we could expand on this)

Successful runs from https://github.com/trailofbits/firebreak/actions/runs/4000633233