### PR TITLE
Fix default dir

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ on:
         description: "the directory to run the lint in"
         required: false
         type: string
-        default: ${{ github.workspace }}
+        default: "."
       continue-on-error:
         description: "don't mark the job as failed if a lint fails"
         default: false
@@ -121,7 +121,6 @@ jobs:
         with:
           go-version-file: "${{ inputs.directory }}/go.mod"
           go-version: "${{ inputs.go-version }}"
-          working-directory: "${{ inputs.directory }}"
 
       - name: run golangci-lint (go)
         if: inputs.language == 'go' && inputs.type == ''


### PR DESCRIPTION
Fixes the default directory to be `.`. It seems like you can't use an expression as a default input variable:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/12104969/216140750-e2597d6f-f909-48bf-9103-96ea8968d5a8.png">
