### PR TITLE
Lint with Trunk.io

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,13 @@
 on:
   workflow_call:
+    inputs:
+      type:
+        description: "use make or just to install project dependencies"
+        required: false
+        type: choice
+        options:
+          - make
+          - just
 
 jobs:
   lint:
@@ -9,13 +17,17 @@ jobs:
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3
 
-      - name: Setup just
-        uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76 # pin@v1
+      - name: install just, if required
+        if: inputs.type == 'just'
+        run: cargo install just
 
-      - name: Install Dependencies and Build
-        run: just dev || make dev
-        # not every language needs to install dependencies
-        continue-on-error: true
+      - name: install dependencies with make, if required
+        if: inputs.type == 'make'
+        run: make deps
 
-      - name: Trunk Check
+      - name: install dependencies with just, if required
+        if: inputs.type == 'just'
+        run: just deps
+
+      - name: trunk check
         uses: trunk-io/trunk-action@9cf65e08e822e9842fd9ef7ed2a2bd9092de0986 # pin@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,167 +1,21 @@
 on:
   workflow_call:
-    inputs:
-      type:
-        description: "the expected lint entrypoint (derived from language by default)"
-        default: ""
-        required: false
-        type: string
-      language:
-        description: "the language to configure"
-        required: true
-        type: string
-      directory:
-        description: "the directory to run the lint in"
-        required: false
-        type: string
-        default: "."
-      continue-on-error:
-        description: "don't mark the job as failed if a lint fails"
-        default: false
-        required: false
-        type: boolean
-      python-version:
-        description: "the version of Python to configure, if any (can be SemVer-formatted)"
-        default: ""
-        required: false
-        type: string
-      go-version:
-        description: "the Go version"
-        default: ""
-        required: false
-        type: string
-      golangci-lint-version:
-        description: "the golangci-lint version for Go linting"
-        default: "v1.50.1"
-        required: false
-        type: string
-      cargo-sort:
-        description: "run cargo-sort as part of Rust linting"
-        default: false
-        required: false
-        type: boolean
-      org-repo-ref:
-        description: "the ref: branch or commit to use of the org repo"
-        default: "main"
-        required: false
-        type: string
-
-env:
-  # Rust: GitHub Actions supports color codes, so always enable them.
-  CARGO_TERM_COLOR: always
-
-  # Python: Tell ruff that we're in GitHub Actions, so that it emits annotations.
-  RUFF_FORMAT: github
-
-  # Python: Make-based linting workflows use `INSTALL_EXTRA` to optimize
-  # the subset of development dependencies installed.
-  INSTALL_EXTRA: lint
-
-  ORG_REPO: trailofbits/.github
-  ORG_REPO_REF: ${{ inputs.org-repo-ref }}
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3
 
-      # Python
-      - name: configure python, if required
-        if: inputs.language == 'python'
-        uses: actions/setup-python@v4
-        with:
-          python-version: "${{ inputs.python-version }}"
-          python-version-file: "${{ inputs.directory }}/.python-version"
-          cache: pip
-          cache-dependency-path: |
-            **/pyproject.toml
-            **/requirements*.txt
+      - name: Setup just
+        uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76 # pin@v1
 
-      # Rust
-      - name: configure rust and clippy, if required
-        if: inputs.language == 'rust'
-        continue-on-error: ${{ inputs.continue-on-error }}
-        working-directory: "${{ inputs.directory }}"
-        run: |
-          # we always run the latest stable Rust and Clippy for Rust linting.
-          rustup update
-          rustup component add clippy
+      - name: Install Dependencies and Build
+        run: just dev || make dev
+        # not every language needs to install dependencies
+        continue-on-error: true
 
-      - name: run rustfmt (rust)
-        if: inputs.language == 'rust' && inputs.type == ''
-        continue-on-error: ${{ inputs.continue-on-error }}
-        working-directory: "${{ inputs.directory }}"
-        run: cargo fmt --check
-
-      - name: run clippy (rust)
-        # NOTE: This is a fork of the original `actions-rs/clippy-check`,
-        # which is no longer maintained; the commit is pinned since no release
-        # has been made and its long term maintenance status/ownership is unclear.
-        if: inputs.language == 'rust' && inputs.type == ''
-        continue-on-error: ${{ inputs.continue-on-error }}
-        uses: actions-rs-plus/clippy-check@5eb300cdebee2681ff8513b9348b0ca793d8a293
-        with:
-          args: --all-features -- -D warnings
-          working-directory: "${{ inputs.directory }}"
-
-      - name: run cargo sort (rust)
-        if: inputs.language == 'rust' && inputs.type == ''
-        continue-on-error: ${{ inputs.continue-on-error }}
-        working-directory: "${{ inputs.directory }}"
-        run: |
-          cargo install cargo-sort
-          cargo sort -c
-
-      # Go
-      - name: configure go, if required
-        if: inputs.language == 'go'
-        continue-on-error: ${{ inputs.continue-on-error }}
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: "${{ inputs.directory }}/go.mod"
-          go-version: "${{ inputs.go-version }}"
-
-      - name: run golangci-lint (go)
-        if: inputs.language == 'go' && inputs.type == ''
-        continue-on-error: ${{ inputs.continue-on-error }}
-        uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # @v3.3.1
-        with:
-          version: "${{ inputs.golangci-lint-version }}"
-          working-directory: "${{ inputs.directory }}"
-
-      # Markdown
-      - name: download markdownlint config
-        if: inputs.language == 'markdown'
-        run: |
-          curl \
-            https://raw.githubusercontent.com/${{ env.ORG_REPO }}/${{ env.ORG_REPO_REF }}/configs/default.markdownlint.jsonc \
-              > /tmp/default.markdownlint.jsonc
-
-      - name: run markdownlint-cli2
-        if: inputs.language == 'markdown'
-        continue-on-error: ${{ inputs.continue-on-error }}
-        uses: DavidAnson/markdownlint-cli2-action@v9
-        with:
-          command: config
-          globs: |
-            /tmp/default.markdownlint.jsonc
-            **/*.md
-
-      # Make
-      - name: run lint (make)
-        if: (inputs.language == 'python' && inputs.type == '') || inputs.type == 'make'
-        continue-on-error: ${{ inputs.continue-on-error }}
-        run: make lint
-        working-directory: "${{ inputs.directory }}"
-
-      # Just
-      - name: configure just, if required
-        if: inputs.type == 'just'
-        run: cargo install just
-
-      - name: run lint (just)
-        if: inputs.type == 'just'
-        continue-on-error: ${{ inputs.continue-on-error }}
-        run: just lint
-        working-directory: "${{ inputs.directory }}"
+      - name: Trunk Check
+        uses: trunk-io/trunk-action@9cf65e08e822e9842fd9ef7ed2a2bd9092de0986 # pin@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,5 +46,5 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: .trunk/out
+          name: trunk-out
           path: .trunk/out

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,11 +30,11 @@ jobs:
 
       - name: install dependencies with make, if required
         if: inputs.type == 'make'
-        run: make deps
+        run: make dev
 
       - name: install dependencies with just, if required
         if: inputs.type == 'just'
-        run: just deps
+        run: just dev
 
       - name: trunk check
         uses: trunk-io/trunk-action@9cf65e08e822e9842fd9ef7ed2a2bd9092de0986 # pin@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,9 @@ jobs:
 
       - name: install just, if required
         if: inputs.type == 'just'
-        run: cargo install just
+        uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76 # pin@v1
+        with:
+          just-version: '1.13.0'
 
       - name: install dependencies with make, if required
         if: inputs.type == 'make'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,7 @@ on:
       type:
         description: "use make or just to install project dependencies"
         required: false
-        type: choice
-        options:
-          - make
-          - just
+        type: string
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,9 +42,3 @@ jobs:
           check-mode: ${{ inputs.trunk-check-mode }}
           arguments: ${{ inputs.trunk-arguments }}
 
-      - name: upload trunk failure logs, if any
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: trunk-out
-          path: .trunk/out

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,5 +38,7 @@ jobs:
 
       - name: trunk check
         uses: trunk-io/trunk-action@9cf65e08e822e9842fd9ef7ed2a2bd9092de0986 # pin@v1
-
+        with:
+          check-mode: ${{ inputs.trunk-check-mode }}
+          arguments: ${{ inputs.trunk-arguments }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,15 @@ on:
   workflow_call:
     inputs:
       type:
-        description: "use make or just to install project dependencies"
+        description: "Use make or just to install project dependencies"
+        required: false
+        type: string
+      trunk-arguments:
+        description: Extra arguments to pass to trunk
+        required: false
+        type: string
+      trunk-check-mode:
+        description: "Trunk check mode. Leave unset to autodetect changes. Set to 'all' to check the entire repository."
         required: false
         type: string
 
@@ -12,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3
+      - uses: actions/checkout@v3
 
       - name: install just, if required
         if: inputs.type == 'just'
@@ -30,3 +38,6 @@ jobs:
 
       - name: trunk check
         uses: trunk-io/trunk-action@9cf65e08e822e9842fd9ef7ed2a2bd9092de0986 # pin@v1
+        with:
+          trunk-check-mode: ${{ inputs.trunk-check-mode }}
+          trunk-arguments: ${{ inputs.trunk-arguments }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,10 @@ jobs:
         with:
           check-mode: ${{ inputs.trunk-check-mode }}
           arguments: ${{ inputs.trunk-arguments }}
+
+      - name: upload trunk failure logs, if any
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: .trunk/out
+          path: .trunk/out

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,5 +39,5 @@ jobs:
       - name: trunk check
         uses: trunk-io/trunk-action@9cf65e08e822e9842fd9ef7ed2a2bd9092de0986 # pin@v1
         with:
-          trunk-check-mode: ${{ inputs.trunk-check-mode }}
-          trunk-arguments: ${{ inputs.trunk-arguments }}
+          check-mode: ${{ inputs.trunk-check-mode }}
+          arguments: ${{ inputs.trunk-arguments }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,5 @@ jobs:
 
       - name: trunk check
         uses: trunk-io/trunk-action@9cf65e08e822e9842fd9ef7ed2a2bd9092de0986 # pin@v1
-        with:
-          check-mode: ${{ inputs.trunk-check-mode }}
-          arguments: ${{ inputs.trunk-arguments }}
+
 


### PR DESCRIPTION
Lints with trunk check.
Example implementation at https://github.com/trailofbits/firebreak/pull/341

## Repo onboarding process

1. Install the ./trunk script to the root of your repo and check it in.

```
curl -LO https://trunk.io/releases/trunk
chmod +x trunk
```

2. Initialize trunk with `./trunk init`. This will scan your repo and generate a `.trunk/trunk.yaml` with all the required linters.

## Linting workflow

Developers simply need to run `./trunk check` from the root of the repo to get the same CI linting results locally. No need to install anything manually.

Run `./trunk fmt` to fix any linting issues.
Trunk will cache and is diff aware locally so it will only run the appropriate linter and only on affected files.
There is also a VSCode extension that can be set as the default formatter https://marketplace.visualstudio.com/items?itemName=Trunk.io

Native VSCode linting
<img width="796" alt="image" src="https://user-images.githubusercontent.com/12104969/217274740-73508264-7ee7-4232-9b03-ceebdafc5fe0.png">

Trunk sidebar
<img width="564" alt="image" src="https://user-images.githubusercontent.com/12104969/217274828-934b55b7-50c6-466d-ac00-44e692fdacbf.png">

`./trunk check` prompts to auto format
<img width="779" alt="image" src="https://user-images.githubusercontent.com/12104969/217275086-002327a4-e730-45b5-b69e-2f604719b244.png">

PR annotations
<img width="596" alt="image" src="https://user-images.githubusercontent.com/12104969/217297335-b2d3c302-5b99-4cc7-86dc-f9ff2cc30aba.png">

# Risks / downside

The `trunk` binary appears to be closed-source (I can't find the source) and trunk.io is a VC-backed startup. If trunk.io goes under we can still use the linting tools that it's wrapping with a make target. We should probably provide that by default for opensource projects.
