### PR TITLE
Update just action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: install just, if required
         if: inputs.type == 'just'
-        uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76 # pin@v1
+        uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # pin@v1.6.0
         with:
           just-version: '1.13.0'
 


### PR DESCRIPTION
Updates the setup-just action. This should now use `GITHUB_TOKEN` so that we don't get rate limited when trying to install just.