### PR TITLE
bumps trunk so it will use upload-artifact v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
         run: just dev
 
       - name: trunk check
-        uses: trunk-io/trunk-action@v1.1.19
+        uses: trunk-io/trunk-action@4d5ecc89b2691705fd08c747c78652d2fc806a94 #pin@v1.1.19
         with:
           trunk-token: ${{ secrets.TRUNK_TOKEN }}
           check-mode: ${{ inputs.trunk-check-mode }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
         run: just dev
 
       - name: trunk check
-        uses: trunk-io/trunk-action@4f077db8a20117a021b787adbf62729ae143c19e # pin@v1.0.8
+        uses: trunk-io/trunk-action@v1.1.19
         with:
           trunk-token: ${{ secrets.TRUNK_TOKEN }}
           check-mode: ${{ inputs.trunk-check-mode }}


### PR DESCRIPTION
c.f. https://github.com/trailofbits/polytracker/actions/runs/13419962617 (a dependent workflow cannot run on the unchanged main branch of polytracker due to use of `actions/upload-artifact@v3`). I bumped Polytracker's use of upload-artifact to v4 I think last year. 

The offender seems to be the Trunk version, which depends on a deprecated upload-artifact, v3. In 1.1.19 (the latest tag), Trunk appears to use upload-artifact at v4 everywhere: https://github.com/trunk-io/trunk-action/compare/v1.0.8...v1.1.19 

I'm happy to pick a different Trunk tag if that would be better, but would really like to have a Trunk action version that runs!